### PR TITLE
Add fix for swiped users showing up again when back to home page afterr visiting another page

### DIFF
--- a/react-front-end/src/App.js
+++ b/react-front-end/src/App.js
@@ -80,7 +80,7 @@ const App = () => {
       }) 
     }
 
-  }, [loggedIn, preferences]);
+  }, [loggedIn, preferences, matches]);
 
 
   // Getting list of all messages


### PR DESCRIPTION
ISSUE: Swiped users would show up again in the users list (home page, potential matches) after being swiped when you go to another page and come back. 

FIXED: Added 'matches' state as a depency in the useEffect hook where it makes the axios.get request for all users. 